### PR TITLE
Add enabled to pillar example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 pam_access:
+  enabled: True
   allowed_users:
     john:
       - '192.168.200.1'


### PR DESCRIPTION
Add 'enabled: True' to pillar.example so that it's clear that it is required. 